### PR TITLE
[Hotfix] Fix discord error logging not working

### DIFF
--- a/classes.js
+++ b/classes.js
@@ -24,6 +24,7 @@ export class Site {
 		this.hidden = data.hidden || false;
 		this.delay = data.delay || 0;
 		this.counter = this.delay;
+		this.timeoutCounter = 0;
 	}
 
 	get parseProductFn() {

--- a/crawl.js
+++ b/crawl.js
@@ -87,16 +87,21 @@ export default async function(browser, site) {
 		return products;
 
 	} catch(err) {
+		site.counter = (site.delay / 10); // Soft-reset the counter so we can try again sooner
+
 		if (err.name === 'TimeoutError') {
 			error("%s: We somehow timed out?! Maybe it's nothing...", site.domain);
+			
+			site.timeoutCounter++;
+			if (site.timeoutCounter >= 4) {
+				site.timeoutCounter = 0;
+				await sendError(err, site);
+			}
 		} else {
 			error("%s: We had some uncertain error- to be specific:", site.domain);
 			console.error(err);
+			await sendError(err, site);
 		}
-
-		site.counter = (site.delay / 10); // Soft-reset the counter so we can try again sooner
-
-		sendError(err, site);
 
 		return false; // return false will be handled in processProducts()
 	} finally {

--- a/discord.js
+++ b/discord.js
@@ -194,7 +194,7 @@ async function getChannel(site) {
 export async function sendError(error, site) {
 	if (config.discord.logging !== false) {
 		const errorSite = new Site('errors', {
-			name: config.discord.error.channel,
+			name: config.discord.logging.error,
 			category: config.discord.logging.category,
 			hidden: true
 		});


### PR DESCRIPTION
* `554a387` Fix typo in discord error channel property
* `dc72dc3` Hide `TimeoutError` discord logging behind counter